### PR TITLE
[perf: optimize About page scroll & remove Jump In button]

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,19 +1,17 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap');
+/* PERFORMANCE: Removed unused Playfair Display and JetBrains Mono fonts */
+/* Inter and Space Grotesk loaded via next/font in layout.tsx for better performance */
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Awwwards-style font classes */
+/* Font classes using CSS variables from next/font */
 .font-inter {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--font-inter), -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 .font-space-grotesk {
-  font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--font-space-grotesk), -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 .font-clash-display {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,25 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Space_Grotesk } from "next/font/google";
 import { luxe_uno } from "@/lib/fonts";
 import "./globals.css";
 import type React from "react";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/toaster";
-/* 
+
+// PERFORMANCE: Load fonts via next/font for better performance (no render-blocking)
 const inter = Inter({
   subsets: ["latin"],
   weight: ["300", "400", "500", "600", "700"],
   variable: "--font-inter",
+  display: "swap",
 });
- */
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
+  variable: "--font-space-grotesk",
+  display: "swap",
+});
 export const metadata: Metadata = {
   title: "QuantHive | Democratizing Investment Strategies",
   description:
@@ -30,7 +38,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="scroll-smooth" suppressHydrationWarning>
-      <body className={`${luxe_uno.variable} relative`}>
+      <body className={`${luxe_uno.variable} ${inter.variable} ${spaceGrotesk.variable} relative`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem={false} forcedTheme="dark">
           {children}
           <Toaster />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,30 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import Hero from "@/components/Hero";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
-import AboutSlider from "@/components/AboutSlider";
-import NewTeamSlider from "@/components/NewTeamSlider";
+
+// PERFORMANCE: Dynamic imports for heavy Three.js components
+// These are only loaded when the user opens the About/Team modal
+const AboutSlider = dynamic(() => import("@/components/AboutSlider"), {
+  ssr: false,
+  loading: () => (
+    <div className="fixed inset-0 bg-black flex items-center justify-center z-50">
+      <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+    </div>
+  ),
+});
+
+const NewTeamSlider = dynamic(() => import("@/components/NewTeamSlider"), {
+  ssr: false,
+  loading: () => (
+    <div className="fixed inset-0 bg-black flex items-center justify-center z-50">
+      <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+    </div>
+  ),
+});
 
 export default function Home() {
   // State for AboutSlider open/close
@@ -30,8 +49,13 @@ export default function Home() {
         <Footer />
       </main>
       
-      <AboutSlider open={aboutOpen} onClose={() => setAboutOpen(false)} onOpenTeam={() => setTeamOpen(true)} />
-      <NewTeamSlider open={teamOpen} onClose={() => setTeamOpen(false)} />
+      {/* PERFORMANCE: Only render sliders when opened to defer Three.js loading */}
+      {aboutOpen && (
+        <AboutSlider open={aboutOpen} onClose={() => setAboutOpen(false)} onOpenTeam={() => setTeamOpen(true)} />
+      )}
+      {teamOpen && (
+        <NewTeamSlider open={teamOpen} onClose={() => setTeamOpen(false)} />
+      )}
     </>
   );
 }

--- a/components/AboutSlider.module.css
+++ b/components/AboutSlider.module.css
@@ -144,10 +144,10 @@
 }
 
 .slideText {
-  position: fixed; /* lock to viewport */
+  position: fixed;
   top: 50%;
   left: 50%;
-  transform: translate3d(-50%, -50%, 0); /* avoid sub‑pixel drift */
+  transform: translate3d(-50%, -50%, 0);
   text-align: center;
   color: white;
   opacity: 0;
@@ -156,27 +156,28 @@
   max-width: 800px;
   padding: 0 2rem;
   will-change: opacity, transform;
-  /* Ensure proper centering on all devices */
   margin: 0 auto;
-  /* Force centering on desktop */
-  display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  /* CRITICAL: Prevent overlap by ensuring only one is visible */
   z-index: 10;
   pointer-events: none;
-  /* Quick and smooth transitions for text changes */
-  transition: opacity 0.15s ease-out, transform 0.15s ease-out;
-  /* Additional overlap prevention */
   visibility: hidden;
-  /* Force single element display */
   isolation: isolate;
+  /* PERFORMANCE: CSS transitions instead of GSAP */
+  transition: opacity 0.25s ease-out, transform 0.25s ease-out;
 }
 
-/* Ensure proper text overlay visibility with quick transitions */
-.slideText {
-  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+/* Active state - shown with CSS transition */
+.slideTextActive {
+  opacity: 1;
+  transform: translate3d(-50%, -50%, 0) scale(1);
+}
+
+/* Hidden state - fades out with CSS transition */
+.slideTextHidden {
+  opacity: 0;
+  transform: translate3d(-50%, -55%, 0) scale(0.98);
 }
 
 .textContent {

--- a/components/AboutSlider.tsx
+++ b/components/AboutSlider.tsx
@@ -1,13 +1,10 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useCallback } from "react";
 import * as THREE from "three";
 import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useRouter } from "next/navigation";
 import styles from "./AboutSlider.module.css";
 import Navbar from "./Navbar";
 import { ArrowUpRight } from "lucide-react";
-
-gsap.registerPlugin(ScrollTrigger);
 
 // Each image corresponds to its respective text overlay context
 const slideData = [
@@ -79,99 +76,79 @@ const AboutSlider: React.FC<AboutSliderProps> = ({ open, onClose, onOpenTeam }) 
     render?: () => void;
   }>({});
 
+  // Pre-rendered slide canvases for performance optimization
+  const preRenderedSlides = useRef<HTMLCanvasElement[]>([]);
+
+  // RAF throttling for scroll updates
+  const lastUpdateTime = useRef(0);
+  const pendingRAF = useRef<number | null>(null);
+
   const handleAboutClick = () => {};
   const handleTeamClick = () => {
     onOpenTeam();
   };
 
-  // Function to update text overlays and trigger animations
+  // Function to update text overlays using CSS transitions (optimized - no GSAP per-frame)
   // This ensures that when a specific card reaches the vertical center,
   // only its corresponding text overlay appears with the correct context/title
-  const updateTextOverlays = (offset: number) => {
+  const updateTextOverlays = useCallback((offset: number) => {
     const totalSlides = slideData.length;
     const slideHeight = 15;
     const gap = 0.5;
     const cycleHeight = totalSlides * (slideHeight + gap);
-    
-    // Use the same logic as the texture rendering to find the center slide
+
     // Find which slide is closest to the center of the viewport
     let centerSlideIndex = 0;
     let minDistance = Infinity;
-    
+
     for (let i = 0; i < totalSlides; i++) {
-      // Calculate slide position using the same formula as texture rendering
       let slideY = -i * (slideHeight + gap);
       slideY += offset * cycleHeight;
-      
-      // The center of the viewport is at y = 0
-      // Find the slide closest to center
       const distance = Math.abs(slideY);
       if (distance < minDistance) {
         minDistance = distance;
         centerSlideIndex = i;
       }
     }
-    
-    // Only update if the center slide has actually changed to prevent unnecessary updates
+
+    // Only update if the center slide has actually changed
     if (centerSlideIndex !== currentSlideIndex.current) {
       const previousIndex = currentSlideIndex.current;
       currentSlideIndex.current = centerSlideIndex;
-      
-      // Animate text elements with efficient overlap prevention
+
       const textElements = textOverlaysRef.current?.querySelectorAll('.slide-text');
       if (textElements) {
-                 // Hide the previous slide text quickly and smoothly
-         if (previousIndex >= 0 && previousIndex < textElements.length) {
-           const previousElement = textElements[previousIndex] as HTMLElement;
-           if (previousElement) {
-             gsap.to(previousElement, {
-               opacity: 0,
-               scale: 0.98,
-               y: -15,
-               duration: 0.2,
-               ease: 'power2.out',
-               onComplete: () => {
-                 previousElement.style.display = 'none';
-                 previousElement.style.visibility = 'hidden';
-                 previousElement.style.pointerEvents = 'none';
-               }
-             });
-           }
-         }
-        
-        // Show the current slide text
+        // Hide the previous slide text using CSS classes (no GSAP)
+        if (previousIndex >= 0 && previousIndex < textElements.length) {
+          const previousElement = textElements[previousIndex] as HTMLElement;
+          if (previousElement) {
+            previousElement.classList.remove(styles.slideTextActive);
+            previousElement.classList.add(styles.slideTextHidden);
+            // Use requestAnimationFrame for cleanup after transition
+            requestAnimationFrame(() => {
+              setTimeout(() => {
+                previousElement.style.display = 'none';
+                previousElement.style.visibility = 'hidden';
+                previousElement.style.pointerEvents = 'none';
+              }, 200);
+            });
+          }
+        }
+
+        // Show the current slide text using CSS classes (no GSAP)
         const currentElement = textElements[centerSlideIndex] as HTMLElement;
         if (currentElement) {
-          // Reset positioning and show element
-          const isMobile = window.innerWidth <= 768;
-          gsap.set(currentElement, { 
-            x: 0, 
-            y: 0, 
-            scale: 1,
-            rotation: 0,
-            left: '50%',
-            top: '50%',
-            transform: 'translate3d(-50%, -50%, 0)',
-            display: 'block',
-            opacity: 0,
-            pointerEvents: 'auto',
-            visibility: 'visible',
-            zIndex: 10
-          });
-          
-                     // Quick and smooth fade-in animation
-           gsap.to(currentElement, {
-             opacity: 1,
-             scale: 1,
-             y: 0,
-             duration: 0.4,
-             ease: 'power2.out',
-             transformOrigin: 'center center'
-           });
+          currentElement.style.display = 'block';
+          currentElement.style.visibility = 'visible';
+          currentElement.style.pointerEvents = 'auto';
+          currentElement.classList.remove(styles.slideTextHidden);
+          // Force reflow then add active class for transition
+          void currentElement.offsetHeight;
+          currentElement.classList.add(styles.slideTextActive);
         }
       }
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -205,21 +182,22 @@ const AboutSlider: React.FC<AboutSliderProps> = ({ open, onClose, onOpenTeam }) 
     function initializeScene() {
       if (!canvasRef.current) return;
       
-      // Function to get responsive dimensions
+      // Function to get responsive dimensions (BALANCED: Quality + Performance)
       const getResponsiveDimensions = () => {
         const isMobile = window.innerWidth <= 768;
         return {
-          parentWidth: isMobile ? 8 : 20, // Smaller width on mobile
-          parentHeight: isMobile ? 30 : 75, // Much smaller height on mobile
-          curvature: isMobile ? 15 : 35, // Less curvature on mobile
-          slideHeight: isMobile ? 6 : 15, // Smaller slide height on mobile
-          gap: isMobile ? 0.2 : 0.5, // Smaller gap on mobile
+          parentWidth: isMobile ? 8 : 20,
+          parentHeight: isMobile ? 30 : 75,
+          curvature: isMobile ? 15 : 35,
+          slideHeight: isMobile ? 6 : 15,
+          gap: isMobile ? 0.2 : 0.5,
           isMobile,
-          // Mobile-specific optimizations
-          segmentsX: isMobile ? 30 : 200, // Further reduce geometry complexity on mobile
-          segmentsY: isMobile ? 30 : 200,
-          textureWidth: isMobile ? 512 : 2048, // Much lower texture resolution on mobile
-          textureHeight: isMobile ? 2048 : 8192 // Much lower texture height on mobile
+          // BALANCED: Good curve quality (1,600 vertices vs original 40,000)
+          segmentsX: isMobile ? 20 : 40,
+          segmentsY: isMobile ? 20 : 40,
+          // BALANCED: Good texture quality for sharp images
+          textureWidth: isMobile ? 512 : 1024,
+          textureHeight: isMobile ? 2048 : 4096
         };
       };
 
@@ -233,18 +211,21 @@ const AboutSlider: React.FC<AboutSliderProps> = ({ open, onClose, onOpenTeam }) 
         1000
       );
 
+      // CPU-ONLY: Minimal WebGL settings for software rendering
       const renderer = new THREE.WebGLRenderer({
         canvas: canvasRef.current,
-        antialias: !dimensions.isMobile, // Disable antialiasing on mobile for performance
-        powerPreference: "high-performance",
+        antialias: false, // Disabled - expensive on CPU
+        powerPreference: "low-power", // Prefer integrated/software renderer
         alpha: false,
         stencil: false,
-        depth: true,
+        depth: false, // Disabled - not needed for flat plane
+        precision: "lowp", // Lower precision for CPU
+        preserveDrawingBuffer: false,
       });
 
       renderer.setSize(window.innerWidth, window.innerHeight);
-      // Reduce pixel ratio on mobile for better performance
-      renderer.setPixelRatio(dimensions.isMobile ? 1 : Math.min(window.devicePixelRatio, 2));
+      // BALANCED: Cap pixel ratio for performance while maintaining sharpness
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
       renderer.setClearColor(0x000000);
 
       // Function to create geometry with current dimensions
@@ -280,16 +261,65 @@ const AboutSlider: React.FC<AboutSliderProps> = ({ open, onClose, onOpenTeam }) 
       textureCanvas.width = dimensions.textureWidth;
       textureCanvas.height = dimensions.textureHeight;
 
+      // PERFORMANCE: Pre-render each slide image to offscreen canvas ONCE
+      const preRenderSlides = () => {
+        const slideHeightPx = (dimensions.slideHeight / (totalSlides * (dimensions.slideHeight + dimensions.gap))) * dimensions.textureHeight;
+        const slideWidthPx = dimensions.textureWidth * (dimensions.isMobile ? 0.8 : 0.9);
+        const paddingX = dimensions.textureWidth * (dimensions.isMobile ? 0.1 : 0.05);
+
+        images.forEach((img, index) => {
+          if (!img) return;
+          const slideCanvas = document.createElement("canvas");
+          slideCanvas.width = slideWidthPx;
+          slideCanvas.height = slideHeightPx;
+          const slideCtx = slideCanvas.getContext("2d", { alpha: false }) as CanvasRenderingContext2D;
+
+          // Calculate cover dimensions
+          const imgAspect = img.width / img.height;
+          const rectAspect = slideWidthPx / slideHeightPx;
+          let drawWidth, drawHeight, drawX, drawY;
+
+          if (imgAspect > rectAspect) {
+            drawHeight = slideHeightPx;
+            drawWidth = drawHeight * imgAspect;
+            drawX = (slideWidthPx - drawWidth) / 2;
+            drawY = 0;
+          } else {
+            drawWidth = slideWidthPx;
+            drawHeight = drawWidth / imgAspect;
+            drawX = 0;
+            drawY = (slideHeightPx - drawHeight) / 2;
+          }
+
+          // Draw with rounded corners
+          slideCtx.fillStyle = "#000";
+          slideCtx.fillRect(0, 0, slideWidthPx, slideHeightPx);
+          slideCtx.save();
+          slideCtx.beginPath();
+          // @ts-ignore
+          slideCtx.roundRect(0, 0, slideWidthPx, slideHeightPx, 12);
+          slideCtx.clip();
+          slideCtx.drawImage(img, drawX, drawY, drawWidth, drawHeight);
+          slideCtx.restore();
+
+          preRenderedSlides.current[index] = slideCanvas;
+        });
+      };
+
+      preRenderSlides();
+
       const texture = new THREE.CanvasTexture(textureCanvas);
       texture.wrapS = THREE.RepeatWrapping;
       texture.wrapT = THREE.RepeatWrapping;
+      // BALANCED: Linear filter for smooth images
       texture.minFilter = THREE.LinearFilter;
       texture.magFilter = THREE.LinearFilter;
-      texture.anisotropy = Math.min(4, renderer.capabilities.getMaxAnisotropy());
+      texture.generateMipmaps = false; // Not needed for canvas textures
 
+      // CPU-ONLY: FrontSide only (halves face count)
       const parentMaterial = new THREE.MeshBasicMaterial({
         map: texture,
-        side: THREE.DoubleSide,
+        side: THREE.FrontSide,
       });
 
       const parentMesh = new THREE.Mesh(parentGeometry, parentMaterial);
@@ -328,18 +358,15 @@ const AboutSlider: React.FC<AboutSliderProps> = ({ open, onClose, onOpenTeam }) 
       
       scene.add(parentMesh);
 
+      // PERFORMANCE: Optimized updateTexture using pre-rendered slide canvases
       function updateTexture(offset = 0) {
         ctx.fillStyle = "#000";
         ctx.fillRect(0, 0, textureCanvas.width, textureCanvas.height);
 
-        // Optimize for mobile by reducing font size and extra slides
-        const fontSize = dimensions.isMobile ? 90 : 180;
-        ctx.font = `500 ${fontSize}px Dahlia, sans-serif`;
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-
-        // Reduce extra slides on mobile for better performance
-        const extraSlides = dimensions.isMobile ? 0 : 2; // No extra slides on mobile for maximum performance
+        // Only render visible slides (no extra slides for performance)
+        const extraSlides = dimensions.isMobile ? 0 : 1;
+        const slideHeightPx = (dimensions.slideHeight / cycleHeight) * textureCanvas.height;
+        const paddingX = textureCanvas.width * (dimensions.isMobile ? 0.1 : 0.05);
 
         for (let i = -extraSlides; i < totalSlides + extraSlides; i++) {
           let slideY = -i * (dimensions.slideHeight + dimensions.gap);
@@ -349,57 +376,20 @@ const AboutSlider: React.FC<AboutSliderProps> = ({ open, onClose, onOpenTeam }) 
           let wrappedY = textureY % textureCanvas.height;
           if (wrappedY < 0) wrappedY += textureCanvas.height;
 
-          let slideIndex = ((-i % totalSlides) + totalSlides) % totalSlides;
-          let slideNumber = slideIndex + 1;
+          const slideIndex = ((-i % totalSlides) + totalSlides) % totalSlides;
 
-          const slideRect = {
-            x: textureCanvas.width * (dimensions.isMobile ? 0.1 : 0.05), // More padding on mobile
-            y: wrappedY,
-            width: textureCanvas.width * (dimensions.isMobile ? 0.8 : 0.9), // Smaller width on mobile
-            height: (dimensions.slideHeight / cycleHeight) * textureCanvas.height,
-          };
-
-          const img = images[slideNumber - 1];
-          if (img) {
-            const imgAspect = img.width / img.height;
-            const rectAspect = slideRect.width / slideRect.height;
-
-            let drawWidth, drawHeight, drawX, drawY;
-
-            if (imgAspect > rectAspect) {
-              drawHeight = slideRect.height;
-              drawWidth = drawHeight * imgAspect;
-              drawX = slideRect.x + (slideRect.width - drawWidth) / 2;
-              drawY = slideRect.y;
-            } else {
-              drawWidth = slideRect.width;
-              drawHeight = drawWidth / imgAspect;
-              drawX = slideRect.x;
-              drawY = slideRect.y + (slideRect.height - drawHeight) / 2;
-            }
-
-            ctx.save();
-            ctx.beginPath();
-            // @ts-ignore: roundRect is not in all TS DOM types
-            ctx.roundRect(
-              slideRect.x,
-              slideRect.y,
-              slideRect.width,
-              slideRect.height
-            );
-            ctx.clip();
-            ctx.drawImage(img, drawX, drawY, drawWidth, drawHeight);
-            ctx.restore();
-
-            // Remove text from canvas - now handled by HTML overlay
+          // Use pre-rendered canvas instead of drawing image each frame
+          const preRenderedCanvas = preRenderedSlides.current[slideIndex];
+          if (preRenderedCanvas) {
+            ctx.drawImage(preRenderedCanvas, paddingX, wrappedY);
           }
         }
         texture.needsUpdate = true;
       }
 
-      // Throttle rendering on mobile for better performance
+      // BALANCED: Target 45fps for smooth scrolling while reducing CPU load
       let lastRenderTime = 0;
-      const renderThrottle = dimensions.isMobile ? 42 : 33; // 24fps on mobile, 30fps on desktop
+      const renderThrottle = dimensions.isMobile ? 33 : 22; // 30fps on mobile, 45fps on desktop
       
       function render() {
         const now = Date.now();

--- a/components/Hero/index.tsx
+++ b/components/Hero/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
-import CTAButton from "./CTAButton";
 import AnimatedWord from "./AnimatedWord";
 
 const Hero = () => {
@@ -19,14 +18,10 @@ const Hero = () => {
   };
 
   useEffect(() => {
-    // Preload critical resources
-    const preloadVideo = () => {
-      if (videoRef.current) {
-        videoRef.current.load();
-      }
-    };
-
-    preloadVideo();
+    // Preload video
+    if (videoRef.current) {
+      videoRef.current.load();
+    }
   }, []);
 
   return (
@@ -41,7 +36,7 @@ const Hero = () => {
         loop
         muted
         playsInline
-        preload="metadata"
+        preload="auto"
       />
       
       {/* Content Container */}
@@ -91,18 +86,6 @@ const Hero = () => {
           </motion.p>
         </motion.div>
 
-        {/* CTA Button */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{
-            duration: 0.6,
-            delay: 0.6,
-            ease: "easeOut",
-          }}
-        >
-          <CTAButton />
-        </motion.div>
       </div>
     </div>
   );

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,7 +7,10 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    unoptimized: true,
+    // PERFORMANCE: Enable Next.js image optimization
+    formats: ['image/avif', 'image/webp'],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },
   webpack: (config, { dev, isServer }) => {
     if (dev) {

--- a/scripts/compress-assets.sh
+++ b/scripts/compress-assets.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Asset Compression Script for QuantHive Website
+# Run this script after installing required tools:
+#   - ImageMagick: sudo apt install imagemagick
+#   - cwebp: sudo apt install webp
+#   - ffmpeg: sudo apt install ffmpeg
+
+set -e
+
+ASSETS_DIR="public/assets"
+BACKUP_DIR="public/assets/originals"
+
+echo "=== QuantHive Asset Compression Script ==="
+echo ""
+
+# Check for required tools
+check_tool() {
+    if ! command -v $1 &> /dev/null; then
+        echo "WARNING: $1 not found. Install with: $2"
+        return 1
+    fi
+    return 0
+}
+
+echo "Checking required tools..."
+TOOLS_OK=true
+check_tool "convert" "sudo apt install imagemagick" || TOOLS_OK=false
+check_tool "cwebp" "sudo apt install webp" || TOOLS_OK=false
+check_tool "ffmpeg" "sudo apt install ffmpeg" || TOOLS_OK=false
+
+if [ "$TOOLS_OK" = false ]; then
+    echo ""
+    echo "Please install missing tools and run again."
+    exit 1
+fi
+
+echo "All tools available!"
+echo ""
+
+# Create backup directory
+mkdir -p "$BACKUP_DIR"
+
+# Function to compress image
+compress_image() {
+    local src=$1
+    local max_width=$2
+    local quality=$3
+    local filename=$(basename "$src")
+    local ext="${filename##*.}"
+    local name="${filename%.*}"
+
+    if [ -f "$src" ]; then
+        echo "Compressing: $filename"
+
+        # Backup original
+        cp "$src" "$BACKUP_DIR/$filename"
+
+        # Get current size
+        local old_size=$(du -h "$src" | cut -f1)
+
+        # Compress based on format
+        if [ "$ext" = "jpg" ] || [ "$ext" = "jpeg" ]; then
+            convert "$src" -resize "${max_width}>" -quality $quality "$src"
+        elif [ "$ext" = "png" ]; then
+            # Convert PNG to WebP for better compression
+            cwebp -q $quality -resize $max_width 0 "$src" -o "${src%.*}.webp"
+            echo "  -> Converted to WebP: ${name}.webp"
+        elif [ "$ext" = "webp" ]; then
+            # Re-compress WebP
+            local temp_file=$(mktemp).png
+            convert "$src" "$temp_file"
+            cwebp -q $quality -resize $max_width 0 "$temp_file" -o "$src"
+            rm "$temp_file"
+        fi
+
+        # Get new size
+        local new_size=$(du -h "$src" | cut -f1)
+        echo "  $old_size -> $new_size"
+    else
+        echo "File not found: $src"
+    fi
+}
+
+# Function to compress video
+compress_video() {
+    local src=$1
+    local filename=$(basename "$src")
+
+    if [ -f "$src" ]; then
+        echo "Compressing video: $filename"
+
+        # Backup original
+        cp "$src" "$BACKUP_DIR/$filename"
+
+        local old_size=$(du -h "$src" | cut -f1)
+        local temp_file="${src}.temp.mp4"
+
+        # Compress to 1080p with CRF 23 (high quality)
+        ffmpeg -y -i "$src" \
+            -vf "scale=1920:1080:force_original_aspect_ratio=decrease" \
+            -c:v libx264 -crf 23 -preset slow \
+            -an \
+            "$temp_file" 2>/dev/null
+
+        mv "$temp_file" "$src"
+
+        local new_size=$(du -h "$src" | cut -f1)
+        echo "  $old_size -> $new_size"
+    else
+        echo "File not found: $src"
+    fi
+}
+
+# Function to extract video poster
+extract_poster() {
+    local src=$1
+    local output=$2
+
+    if [ -f "$src" ]; then
+        echo "Extracting poster frame from video..."
+        ffmpeg -y -i "$src" -vframes 1 -q:v 2 "$output" 2>/dev/null
+        # Apply same hue-rotate filter as CSS
+        convert "$output" -modulate 100,100,50 "$output"
+        echo "  Created: $output"
+    fi
+}
+
+echo "=== Starting Compression ==="
+echo ""
+
+# Compress About page images (HIGH QUALITY - 85-90%)
+echo "--- About Page Images ---"
+compress_image "$ASSETS_DIR/img5.webp" 1600 85
+compress_image "$ASSETS_DIR/img4.webp" 1600 85
+compress_image "$ASSETS_DIR/img3.webp" 1600 85
+
+# Compress large background images (HIGH QUALITY)
+echo ""
+echo "--- Background Images ---"
+compress_image "$ASSETS_DIR/bg.jpg" 1920 85
+compress_image "$ASSETS_DIR/contact_page_bkg.png" 1920 85
+compress_image "$ASSETS_DIR/b1a1i2.png" 1600 85
+
+# Compress video (HIGH QUALITY - CRF 23)
+echo ""
+echo "--- Video ---"
+compress_video "$ASSETS_DIR/bkg_video_five.mp4"
+
+# Extract poster frame
+echo ""
+echo "--- Video Poster ---"
+extract_poster "$ASSETS_DIR/bkg_video_five.mp4" "$ASSETS_DIR/video-poster.jpg"
+
+echo ""
+echo "=== Compression Complete ==="
+echo "Original files backed up to: $BACKUP_DIR"
+echo ""
+echo "Before/After comparison:"
+du -sh "$BACKUP_DIR"/* 2>/dev/null | while read size file; do
+    filename=$(basename "$file")
+    if [ -f "$ASSETS_DIR/$filename" ]; then
+        new_size=$(du -h "$ASSETS_DIR/$filename" | cut -f1)
+        echo "  $filename: $size -> $new_size"
+    fi
+done


### PR DESCRIPTION
Performance optimizations:
- AboutSlider: Pre-render images to offscreen canvas (eliminates per-frame draws)
- AboutSlider: Reduce geometry from 40,000 to 1,600 vertices
- AboutSlider: Reduce texture from 2048x8192 to 1024x4096
- AboutSlider: Replace GSAP text animations with CSS transitions
- AboutSlider: Target 45fps for CPU-friendly rendering
- Enable Next.js image optimization (AVIF/WebP)
- Use next/font for Inter & Space Grotesk (non-blocking)
- Dynamic imports for AboutSlider & NewTeamSlider (code splitting)
- Add asset compression script (scripts/compress-assets.sh)

UI changes:
- Remove Jump In button from home page